### PR TITLE
feat: Add RIO generation with OpenAI integration

### DIFF
--- a/packages/agents/vickie-bennie/src/lib/functions/comsFunctions/GenerateRIOs.ts
+++ b/packages/agents/vickie-bennie/src/lib/functions/comsFunctions/GenerateRIOs.ts
@@ -1,0 +1,132 @@
+import { Context, MachineEvent } from "@codestrap/developer-foundations-types";
+import { extractJsonFromBackticks, uuidv4 } from "@codestrap/developer-foundations-utils";
+
+export type RIO = {
+    category: 'Risk' | 'Insight' | 'Opportunity';
+    subHeader: string;
+    description: string;
+}
+
+export type RIOReport = {
+    id: string;
+    rios: RIO[];
+    summary: string;
+}
+
+export async function generateRIOs(context: Context, event?: MachineEvent, task?: string): Promise<RIOReport> {
+    const response = await fetch('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${process.env.OPEN_AI_KEY}`
+        },
+        body: JSON.stringify({
+            model: "gpt-4o",
+            input: [
+                {
+                    role: "system",
+                    content: [
+                        {
+                            type: "input_text",
+                            text: `You are an expert RIO (Risks, Insights, and Opportunities) analyst. Your job is to research the given task, gather relevant information from the web, and transform your findings into structured, actionable insights.
+
+                                    RIO Structure:
+                                    - Category: Risk, Insight, or Opportunity
+                                    - Sub-Header: Brief descriptive title (2-5 words)
+                                    - Description: Single paragraph explaining context and details with actionable guidance
+
+                                    Criteria for effective RIOs:
+                                    1. Actionable: Provide clear pathway for action or specific questions
+                                    2. Timely: Focus on current/upcoming issues with appropriate urgency
+                                    3. Relevant: Tailored to user's context, industry, or specific needs
+                                    4. Important: High-priority information that impacts business outcomes
+
+                                    Process:
+                                    1. Research the given task thoroughly using web search
+                                    2. Gather current information, trends, and relevant data
+                                    3. Analyze the findings to identify risks, insights, and opportunities
+                                    4. Generate 3-5 RIOs per category (Risk, Insight, Opportunity)
+                                    5. Prioritize the most pressing and impactful RIOs first
+                                    6. Keep descriptions concise but informative enough to prompt action
+
+                                    Example RIOs:
+
+                                    Risk Examples:
+                                    - Sub-Header: "Supply Chain Disruption"
+                                    Description: "There is an anticipated shortage of key materials due to recent international shipping delays. This could lead to production halts. Mitigate by identifying alternate suppliers and increasing inventory stock now."
+
+                                    - Sub-Header: "Data Security Breach"
+                                    Description: "Recent cyber attacks targeting similar businesses indicate increased vulnerability. Increase security protocols by conducting an immediate audit and implementing multi-factor authentication across all systems."
+
+                                    Insight Examples:
+                                    - Sub-Header: "Customer Behavior Shift"
+                                    Description: "Recent data shows a 10% increase in mobile shopping across your customer base. Consider optimizing your mobile experience to capitalize on this growing trend and improve conversion rates."
+
+                                    - Sub-Header: "Industry AI Adoption"
+                                    Description: "Competitors are adopting AI for process automation, providing 30% cost savings. Consider adopting similar strategies to maintain competitive advantage and reduce operational costs."
+
+                                    Opportunity Examples:
+                                    - Sub-Header: "New Revenue Stream"
+                                    Description: "Expanding your product line into the X region could increase sales by 15% based on favorable market trends. Begin market research and strategy alignment to enter this region next quarter."
+
+                                    - Sub-Header: "Partnership Available"
+                                    Description: "X Company is seeking strategic partnerships in your sector. Reach out to explore collaboration opportunities that could expand your market reach and share development costs."
+
+                                    Format your response as a JSON object with this structure:
+                                    {
+                                    "rios": [
+                                        {
+                                        "category": "Risk|Insight|Opportunity",
+                                        "subHeader": "Brief title",
+                                        "description": "Detailed description with actionable guidance"
+                                        }
+                                    ],
+                                    "summary": "Brief overview of the RIO analysis and research findings"
+                                    }`
+                        }
+                    ]
+                },
+                {
+                    role: "user",
+                    content: [
+                        {
+                            type: "input_text",
+                            text: `Please research the following task and generate RIOs:\n\n${task}`
+                        }
+                    ]
+                }
+            ],
+            text: {
+                format: {
+                    type: "text"
+                }
+            },
+            reasoning: {},
+            tools: [
+                {
+                    type: "web_search_preview",
+                    user_location: {
+                        type: "approximate",
+                        country: "US",
+                    },
+                    search_context_size: "high"
+                }
+            ],
+            temperature: 0.7,
+            max_output_tokens: 4096,
+            top_p: 1,
+            store: true
+        })
+    });
+
+    const data = await response.json() as any;
+    const content = data.output?.filter((message: { type: string }) => message.type === 'message')?.[0]?.content?.[0]?.text;
+    const result = extractJsonFromBackticks(content ?? "{}");
+    const parsedContent = JSON.parse(result);
+
+    return {
+        id: uuidv4(),
+        rios: parsedContent.rios || [],
+        summary: parsedContent.summary || 'RIO analysis completed.'
+    };
+} 

--- a/packages/agents/vickie-bennie/src/lib/reasoning/context/coms/functionCatalog.ts
+++ b/packages/agents/vickie-bennie/src/lib/reasoning/context/coms/functionCatalog.ts
@@ -20,6 +20,7 @@ import {
   sendSlackMessage,
   writeSlackMessage,
 } from '../../../functions';
+import { generateRIOs } from '../../../functions/comsFunctions/GenerateRIOs';
 
 
 function getPayload(context: Context, result: Record<string, any>) {
@@ -108,6 +109,24 @@ export function getFunctionCatalog(dispatch: (action: ActionType) => void) {
                     const payload = getPayload(context, result);
                     console.log(`researchReport returned: ${JSON.stringify(result)}`);
                     console.log('dispatching CONTINUE from researchReport');
+
+                    dispatch({
+                        type: 'CONTINUE',
+                        payload,
+                    });
+                },
+            },
+        ],
+        [
+            "generateRIOs",
+            {
+                description:
+                    "Generates RIOs (Risks, Insights, and Opportunities) by researching the given task and providing structured, actionable insights.",
+                implementation: async (context: Context, event?: MachineEvent, task?: string) => {
+                    const result = await generateRIOs(context, event, task);
+                    const payload = getPayload(context, result);
+                    console.log(`generateRIOs returned: ${JSON.stringify(result)}`);
+                    console.log('dispatching CONTINUE from generateRIOs');
 
                     dispatch({
                         type: 'CONTINUE',


### PR DESCRIPTION
This PR introduces a function that generates Risk, Insight, and Opportunity (RIO) outputs using OpenAI, for the details passed via task parameters provided by the solver or programmer.

Improvements:
This can be further improved by grounding the rio generation with more relevant data from the ontology 
- such as recent communications 
- or if it is combined contextual functions like recall and user profile .

Future scope:
a very vague idea how it can be useful
- We can have the solver call this function at the end of the workflow execution to create the relevant RIOs based on the information present in the context at the end of workflow and store those rios into the ontology. 
- another function getRIOs will be able to search and fetch most relevent RIO for user if user ask for some insights around any sales or coms process.
- This logic could evolve into a standalone insight engine that continuously surfaces opportunities, risks, or emerging trends across workflows.


